### PR TITLE
Add ability for easy debugs on stl templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# CPP_Competitive_Programming_Atom_Snippets
+# CPP: Competitive_Programming Atom Snippets
 A collection of code snippets for competitive programmers, written in C++ for atom editor.
+---
 
-Many times this happens in competitive programming competitions that you&#39;ve figured out an algorithm for the solution of the problem, which happens to be a standard algorithm. How helpful would it be to have snippets for commonly used concepts/algorithms in competitive programming in that situation, to provide you an edge over fellow competitors as using snippets will improve your accuracy, speed and hence rank!
+Many a times it happens in competitive programming competitions that you&#39;ve figured out an algorithm for the solution of the problem, which happens to be a standard algorithm. How helpful would it be to have snippets for the commonly used concepts/algorithms in that situation, to provide you an edge over the fellow competitors. Using snippets will improve your accuracy, speed and hence rank!
 
 This repository provides extension for atom-text editor which enables atom users to use c++ coding snippets of algorithms while doing competitive programming.
 
@@ -39,3 +40,7 @@ Following table contains all the snippets available in this package. It gives in
 | splitString.cpp | split-string | Split a c++ string by a delimiter |
 | suffixArray.cpp |  suffix-array | Suffix array and LCP array |
 | binarySearch.cpp | binary-search | Binary Search |
+| printVector.cpp | print-vector | Overload ostream operator << to print a vector for debugging |
+| printPair.cpp | print-pair | Overload ostream operator << to print a pair for debugging |
+| printSet.cpp | print-set | Overload ostream operator << to print a set for debugging |
+| printMap.cpp | print-map | Overload ostream operator << to print a map for debugging |

--- a/snippets/presentation.cson
+++ b/snippets/presentation.cson
@@ -1,0 +1,64 @@
+'.source.cpp, .source.cc':
+
+  'Overload << operator to print a vector for easy debugging':
+    'prefix': 'print-vector'
+    'body': '''
+		template <typename T>
+		ostream& operator<<(ostream& os, const vector<T>& v)
+		{
+			os << "[";
+			std::string delim = "";
+			for (int i = 0; i < v.size(); ++i) {
+				os << delim << v[i];
+				delim = ", ";
+			}
+			os << "]";
+			return os;
+		}
+    '''
+
+  'Overload << operator to print a set for easy debugging':
+    'prefix': 'print-set'
+    'body': '''
+		template <typename T>
+		ostream& operator<<(ostream& os, const set<T>& v)
+		{
+			os << "{";
+      std::string delim = "";
+			for (auto it : v) {
+				os << delim << it;
+        delim = ", ";
+			}
+			os << "}";
+			return os;
+		}
+    '''
+  'Overload << operator to print a pair for easy debugging':
+    'prefix': 'print-pair'
+    'body': '''
+		template <typename T, typename S>
+		ostream& operator<<(ostream& os, const pair<T, S>& v)
+		{
+			os << "(";
+			os << v.first << ", "
+			<< v.second << ")";
+			return os;
+		}
+    '''
+	
+  'Overload << operator to print a map  for easy debugging':
+    'prefix': 'print-map'
+    'body': '''
+		template <typename T, typename S>
+		ostream& operator<<(ostream& os, const map<T, S>& v)
+		{
+      std::string delim = "";
+			os << "{";
+			for (auto it : v){
+        os << delim <<  it.first << ":" << it.second;
+        delim = ", ";
+      }
+			os << "}";
+			return os;
+		}
+    '''


### PR DESCRIPTION
Hi, your extension has been very helpful. I've forked your repository and added some snippets that help a programmer to quickly print a vector, set, map, pair during programming. These are templated. As time is of the essence, it'll be crucial for debugging.
I'd like you to review the pull.
![untitled](https://user-images.githubusercontent.com/12872673/42022029-c72feeb8-7ad9-11e8-91b0-f430c06515b1.png)
