### PR TITLE
corrected all(c) macro, made function names CAPS

### DIFF
--- a/snippets/basic.cson
+++ b/snippets/basic.cson
@@ -12,6 +12,7 @@
 	#include <complex>
 	#define endl "\\\\n"
 	#define ll long long int
+	#define ull unsigned long long
 	#define vi vector<int>
 	#define vll vector<ll>
 	#define vvi vector < vi >
@@ -19,9 +20,9 @@
 	#define pll pair<long long, long long>
 	#define mod 1000000007
 	#define inf 1000000000000000001;
-	#define all(c) c.begin(),c.end()
-	#define mp(x,y) make_pair(x,y)
-	#define mem(a,val) memset(a,val,sizeof(a))
+	#define ALL(c) (c).begin(),(c).end()
+	#define MP(x,y) make_pair(x,y)
+	#define MEM(a,val) memset(a,val,sizeof(a))
 	#define eb emplace_back
 	#define f first
 	#define s second


### PR DESCRIPTION
The g++ compiler does not support the **all(c)** macro.
instead of c.something you need to write (c).something